### PR TITLE
plugin: add alternative reducer support for layout plugin

### DIFF
--- a/packages/core/src/reducer/editable/tree.js
+++ b/packages/core/src/reducer/editable/tree.js
@@ -47,7 +47,7 @@ export const cell = (state: Cell, action: Object): Cell =>
           ['content', 'plugin', 'reducer'],
           state
         )
-        const layout = pathOr(identity, ['content', 'layout', 'reducer'], state)
+        const layout = pathOr(identity, ['layout', 'plugin', 'reducer'], state)
 
         return content(
           layout(

--- a/packages/core/src/service/plugin/classes.js
+++ b/packages/core/src/service/plugin/classes.js
@@ -89,7 +89,8 @@ export class Plugin {
       handleFocusNextHotKey,
       handleFocusPreviousHotKey,
       handleFocus,
-      handleBlur
+      handleBlur,
+      reducer
     } = config
 
     if (!name || !version || !Component) {
@@ -122,6 +123,7 @@ export class Plugin {
       : this.handleFocusPreviousHotKey
     this.handleFocus = handleFocus ? handleFocus.bind(this) : this.handleFocus
     this.handleBlur = handleBlur ? handleBlur.bind(this) : this.handleBlur
+    this.reducer = reducer ? reducer.bind(this) : this.reducer
   }
 
   config: any
@@ -229,6 +231,14 @@ export class Plugin {
    * @param props
    */
   handleBlur = (props: ContentPluginProps<*>): void => {}
+
+  /**
+   * Specify a custom reducer for the plugin's cell.
+   *
+   * @param state
+   * @param action
+   */
+  reducer = (state: any, action: any) => state
 }
 
 /**
@@ -241,12 +251,10 @@ export class ContentPlugin extends Plugin {
       createInitialState,
       allowInlineNeighbours = false,
       isInlineable = false,
-      reducer
     } = config
 
     this.isInlineable = isInlineable
     this.allowInlineNeighbours = allowInlineNeighbours
-    this.reducer = reducer ? reducer.bind(this) : this.reducer
     this.createInitialState = createInitialState
       ? createInitialState.bind(this)
       : this.createInitialState
@@ -316,14 +324,12 @@ export class NativePlugin extends Plugin {
       createInitialState,
       allowInlineNeighbours = false,
       isInlineable = false,
-      reducer,
       createInitialChildren,
       type = 'content'
     } = config
 
     this.isInlineable = isInlineable
     this.allowInlineNeighbours = allowInlineNeighbours
-    this.reducer = reducer ? reducer.bind(this) : this.reducer
     this.createInitialState = createInitialState
       ? createInitialState.bind(this)
       : this.createInitialState
@@ -361,12 +367,4 @@ export class NativePlugin extends Plugin {
    * @returns the initial state.
    */
   createInitialState = (): Object => ({})
-
-  /**
-   * Specify a custom reducer for the plugin's cell.
-   *
-   * @param state
-   * @param action
-   */
-  reducer = (state: any, action: any) => state
 }


### PR DESCRIPTION
Hello,

I followup a recently added feature request #509 by this PR

My use case is a layout plugin that shares some of its state with other plugins, with some data transformations during synchronization ...
To achieve this, we have created a special HOC that subscribes to ory store, looks for target states based on filter criteria, and maps the results to the current / wrapped plugin. the solution works as expected but it has a performance impact and it is declarative (we prefer it imperative for more control).

By using the option "reducer" of plugin we can achieve the same without the cons of the HOC solution. but unfortunately, the layout plugin does not support it. this PR is about adding "reducer" option support  for the layout plugin .

Please review this PR and consider merging it.

If you have ideas about state sharing between plugins, we are interested in hearing them.