### PR TITLE
feat(doc): add pre-commit githook to regenerate documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "postcss-cssnext": "^2.10.0",
     "postcss-import": "^9.1.0",
     "postcss-nested": "^2.0.2",
+    "pre-commit": "^1.2.2",
     "prettier": "^1.6.1",
     "pushstate-server": "^3.0.0",
     "react": "^15.5.4",
@@ -44,7 +45,7 @@
     "build:watch": "cross-env NODE_ENV=development lerna run build:watch --parallel --stream",
     "clean": "lerna run clean",
     "clean:lerna": "lerna clean --yes",
-    "docs:api": "lerna run docs --stream",
+    "docs:api": "cross-env NODE_ENV=development lerna run docs --stream",
     "docs:guide": "gitbook serve -http",
     "flow": "flow check --show-all-errors",
     "flow:generate": "lerna run flow:generate",
@@ -64,6 +65,7 @@
     "heroku-prebuild": "git init",
     "heroku-postbuild": "npm run build"
   },
+  "pre-commit": "docs:api",
   "jest": {
     "testPathIgnorePatterns": [
       "/examples/"


### PR DESCRIPTION
Following discussion on issue https://github.com/ory/editor/issues/524

Here is a precommit hook to run the docs:api on every commit mail. Then the commiter will see the lerna message and the new unstaged files and can decide to add them in a new commit or not (nothing mandatory so it's simpler).

Another option would be to run the doc generation on origin repo after each change on the master branch but I'm not sure how to do this and I lack access to give it a try. 