### PR TITLE
Add ory-plugins-content-slate-container class to outer slate div

### DIFF
--- a/packages/plugins/content/slate/src/Component/index.js
+++ b/packages/plugins/content/slate/src/Component/index.js
@@ -127,6 +127,7 @@ class Slate extends Component {
           onChange={this.onStateChange}
           onKeyDown={onKeyDown}
           readOnly={Boolean(readOnly)}
+          className="ory-plugins-content-slate-container"
           onBlur={onBlur}
           schema={schema}
           state={editorState}

--- a/packages/plugins/content/slate/src/index.js
+++ b/packages/plugins/content/slate/src/index.js
@@ -119,7 +119,7 @@ export default (plugins: Plugin[] = hooks.defaultPlugins) => {
 
   const Slate = (cellProps: Props) => <Component {...cellProps} {...props} />
   const StaticComponent = ({ state: { editorState } = {} }: Props) => (
-    <div dangerouslySetInnerHTML={{ __html: html.serialize(editorState) }} />
+    <div className="ory-plugins-content-slate-container" dangerouslySetInnerHTML={{ __html: html.serialize(editorState) }} />
   )
   return {
     Component: Slate,

--- a/packages/renderer/src/index.test.js
+++ b/packages/renderer/src/index.test.js
@@ -174,7 +174,7 @@ describe('HTMLRenderer', () => {
         const wrapper = render(<HTMLRenderer state={c} plugins={plugins} />)
         it('should pass', () => {
           expect(wrapper.html()).toEqual(
-            '<div class="ory-row"><div class="ory-cell ory-cell-sm-12 ory-cell-xs-12"><div class="ory-cell-inner ory-cell-leaf"><div><p style="text-align:center;">Asdfg</p></div></div></div></div>'
+            '<div class="ory-row"><div class="ory-cell ory-cell-sm-12 ory-cell-xs-12"><div class="ory-cell-inner ory-cell-leaf"><div class="ory-plugins-content-slate-container"><p style="text-align:center;">Asdfg</p></div></div></div></div>'
           )
         })
       })


### PR DESCRIPTION
Currently it is hard to define styles for this container due to no class name. Rather than putting in an issue, thought I would add it. This might have been intentional behaviour / ory user defined behaviour, although I couldn't find any docs for this.

Also I tried to remain consistent with the naming convention I saw, although I'm not 100% certain 'container' is the preferred word in this repo