### PR TITLE
Adds ability to initialize Editor with your own redux store

### DIFF
--- a/packages/core/src/components/Editable/index.js
+++ b/packages/core/src/components/Editable/index.js
@@ -76,7 +76,7 @@ class Editable extends Component {
       return
     }
 
-    const state: any = editable(this.props.editor.store.getState(), {
+    const state: any = editable(this.props.editor.getState(), {
       id: this.props.id
     })
     if (state === this.previousState || !state) {

--- a/packages/core/src/selector/index.js
+++ b/packages/core/src/selector/index.js
@@ -23,7 +23,7 @@
 // @flow
 import { editable, editables } from './editable'
 
-export const selectors = (store: any) => ({
-  editable: (id: string) => editable(store.getState(), { id }),
-  editables: (id: string) => editables(store.getState())
+export const selectors = (getState: any) => ({
+  editable: (id: string) => editable(getState(), { id }),
+  editables: (id: string) => editables(getState())
 })


### PR DESCRIPTION
 Before I complete the PR with the stated TODOs below, are you happy with the decisions I made to implement this feature?

Now you can do 
```js
import { oryReducer } from 'ory-editor/core'

combineReducers({ 
  ory: oryReducer, // must be 'ory' key
  // rest of your reducers
})

// create the store using your reducer

new Editor({ store: store })
```
Fixes #611 

Todos
- [ ] Docs
- [ ] Tests